### PR TITLE
lower case all event names to get handler class

### DIFF
--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -193,7 +193,7 @@ abstract class AbstractProvider implements ProviderContract, Responsable
      */
     protected function prepareHandlerClassname(string $event): string
     {
-        return (string) Str::of($event)->replaceMatches('/[^A-Za-z0-9]++/', ' ')->studly();
+        return (string) Str::of($event)->lower()->replaceMatches('/[^A-Za-z0-9]++/', ' ')->studly();
     }
 
     /**


### PR DESCRIPTION
When working with PayPal webhooks I ran into an issue where by handler wasn't getting called as expected.

PayPal uses all uppercase for their event names in webhooks. For example "PAYMENT.AUTHORIZATION.CREATED". See (https://developer.paypal.com/api/rest/webhooks/event-names/).

Because of this, and because my custom provider was passing in the event name unmodified, I discovered it was looking for a class named "PAYMENTAUTHORIZATIONCREATED" instead of "PaymentAuthorizationCreated".

In the meantime I am working around this by lowercasing the event name before returning it from my custom provider, but I feel this should be handled by the package directly because:

1) Relying the the developer to lowercase event names in their Provider relys on them knowing that is necessary.

2) I can't imagine a scenario where a developer wants to have an all upperclass class name.

Therefore, this PR lowercases all event names when determining the matching class name.